### PR TITLE
Add CI, README, LICENSE, npm publish config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run typecheck
+      - run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test -- --exclude 'src/cli/commands/*.test.ts' --exclude 'tests/e2e/**'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tony Tang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,124 @@
+# logd
+
+CLI tool and MCP server for logging and semantically searching decisions using local LLM embeddings.
+
+Decisions are stored in a local SQLite database with vector embeddings (via [sqlite-vec](https://github.com/asg017/sqlite-vec)) for semantic search. Embeddings are computed locally using [Ollama](https://ollama.com/) with Qwen3-Embedding-0.6B.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 22
+- [Ollama](https://ollama.com/) running locally with the embedding model:
+
+```bash
+ollama pull qwen3-embedding:0.6b
+```
+
+## Install
+
+```bash
+npm install -g logd
+```
+
+Or run from source:
+
+```bash
+git clone https://github.com/tonytangdev/logd.git
+cd logd
+npm install
+npm run build
+npm link
+```
+
+## Usage
+
+### Manage projects
+
+Decisions are scoped by project. Create a project first:
+
+```bash
+logd project create "my-app" -d "Main application"
+logd project list
+```
+
+### Add decisions
+
+```bash
+logd add "Use Postgres for persistence" -p my-app -c "Need ACID transactions" -t backend -t database
+logd add "Choose React over Vue" -p my-app -a "Vue" -a "Svelte" -t frontend
+```
+
+### Search decisions
+
+```bash
+logd search "what database did we choose?"
+logd search "frontend framework" -p my-app --verbose
+logd search "database" --threshold 0.5 --limit 3
+```
+
+### View, edit, delete
+
+```bash
+logd show <id>
+logd edit <id> --status superseded
+logd edit <id> -t new-tag-1 -t new-tag-2  # replaces all tags
+logd delete <id>
+logd list -p my-app --status active
+```
+
+## MCP Server
+
+Start the MCP server for AI agent integration:
+
+```bash
+logd serve
+```
+
+Add to your Claude Code MCP config (`~/.claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "logd": {
+      "command": "logd",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+### Available tools
+
+| Tool | Description |
+|---|---|
+| `logd_add_decision` | Create a decision |
+| `logd_search_decisions` | Semantic search |
+| `logd_show_decision` | Get decision by ID |
+| `logd_edit_decision` | Partial update |
+| `logd_delete_decision` | Delete by ID |
+| `logd_list_decisions` | List with filters |
+| `logd_create_project` | Create project |
+| `logd_list_projects` | List projects |
+
+## Configuration
+
+| Setting | Default | Env var | CLI flag |
+|---|---|---|---|
+| Ollama URL | `http://localhost:11434` | `LOGD_OLLAMA_URL` | `--ollama-url` |
+| Model | `qwen3-embedding:0.6b` | `LOGD_MODEL` | `--model` |
+| DB path | `~/.logd/logd.db` | `LOGD_DB_PATH` | `--db-path` |
+
+Precedence: defaults < env vars < CLI flags.
+
+## Architecture
+
+```
+src/
+  core/     -- business logic, types, config (framework-agnostic)
+  infra/    -- SQLite + sqlite-vec, Ollama client
+  cli/      -- Commander.js commands
+  mcp/      -- MCP server
+```
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
 	"name": "logd",
 	"version": "1.0.0",
-	"description": "",
-	"main": "index.js",
-	"directories": {
-		"doc": "docs"
-	},
+	"description": "CLI tool & MCP server for logging and semantically searching decisions using local LLM embeddings",
+	"main": "dist/src/cli/index.js",
+	"files": [
+		"dist/bin/",
+		"dist/src/",
+		"README.md",
+		"LICENSE"
+	],
 	"scripts": {
 		"format": "biome format --write .",
 		"format:check": "biome check .",
@@ -20,9 +23,17 @@
 		"type": "git",
 		"url": "git+https://github.com/tonytangdev/logd.git"
 	},
-	"keywords": [],
-	"author": "",
-	"license": "ISC",
+	"keywords": [
+		"cli",
+		"decisions",
+		"embeddings",
+		"sqlite",
+		"mcp",
+		"ollama",
+		"semantic-search"
+	],
+	"author": "Tony Tang",
+	"license": "MIT",
 	"type": "commonjs",
 	"bugs": {
 		"url": "https://github.com/tonytangdev/logd/issues"


### PR DESCRIPTION
## Summary
- GitHub Actions CI: lint + typecheck + unit tests (excludes Ollama-dependent CLI/E2E tests)
- README with install, usage, MCP config, architecture
- MIT LICENSE
- package.json: `files` field, description, keywords, author for npm publish

## Test plan
- [x] `npm run format:check` passes
- [x] `npm run typecheck` passes
- [x] CI workflow runs on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)